### PR TITLE
feat: Add Strava integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This app gives athletes the opportunity to challenge their friends and followers
 
 To get the app set up with Strava, do the following:
 
-1.  Navigate to [Strava's API](https://www.strava.com/settings/api)
-2.  Create a new application
-3.  Copy the "Client ID" and "Client Secret" fields
+1. Navigate to [Strava's API](https://www.strava.com/settings/api)
+2. Create a new application
+3. Copy the "Client ID" and "Client Secret" fields
 
 Now you start the app locally with the following command:
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
-## Segment challenge
+# Segment challenge
 
 This app gives athletes the opportunity to challenge their friends and followers for a particular segment or a series of segment while being able to follow social distancing guidelines where cycling is permitted. A challenge will get its own leaderboard, is limited to a certain time period set by the athlete, and by invitation. The Strava leaderboards are not suitable for this type of social distancing challenge as they do not allow for a group of people to view the same leaderboard over a specific time period.
+
+## Strava app setup
+
+To get the app set up with Strava, do the following:
+
+1.  Navigate to [Strava's API](https://www.strava.com/settings/api)
+2.  Create a new application
+3.  Copy the "Client ID" and "Client Secret" fields
+
+Now you start the app locally with the following command:
+
+```sh
+REACT_APP_STRAVA_CLIENT_ID="your-client-id" \
+REACT_APP_STRAVA_CLIENT_SECRET="your-client-secret" \
+yarn start
+```
+
+This can be cleaned up in future PRs by doing things like:
+
+- Saving them as environment variables on your machine (hey, no PR necessary for that!)
+- Saving them into GitHub secrets so that GitHub actions can auto-apply them at build/deploy time in production
+
+As mentioned, this exercise can be deferred to a later date, however.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",
+    "react-simple-oauth2-login": "^0.2.0",
     "web-vitals": "^1.0.1"
   },
   "scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -1,21 +1,12 @@
 import './App.css';
-import ChallengeInputForm from './ChallengeInputForm.js';
+import Contents from './Contents';
+import StravaContainer from './StravaContainer';
 
 function App() {
   return (
-    <div className="stravaChallenge">
-      <h1>The Strava Challenge</h1>
-      <div className="challengeInputForm">
-        <ChallengeInputForm />
-      </div>
-      <div className="challengeList">
-        <div>{/* status */}</div>
-        <ol>{/* TODO */}</ol>
-      </div>
-      <div class="footer">
-        <p>&copy; alexdiem.io</p>
-      </div>
-    </div>
+    <StravaContainer>
+      <Contents />
+    </StravaContainer>
   );
 }
 

--- a/src/Contents/ChallengeInputForm.js
+++ b/src/Contents/ChallengeInputForm.js
@@ -17,8 +17,8 @@ const ChallengeInputForm = () => {
     <div>
       <h3>Open a new challenge:</h3>
       <form id="challengeInputForm" onSubmit={formik.handleSubmit}>
-        <div class="form-group">
-          <label for="challengeSegment">Link to Strava segment </label>
+        <div className="form-group">
+          <label htmlFor="challengeSegment">Link to Strava segment </label>
           <input
             type="text"
             id="challengeSegment"
@@ -27,8 +27,8 @@ const ChallengeInputForm = () => {
             placeholder="Link to Strava segment"
           />
         </div>
-        <div class="form-group">
-          <label for="challengeStartDate">Challenge start date </label>
+        <div className="form-group">
+          <label htmlFor="challengeStartDate">Challenge start date </label>
           <input
             type="date"
             id="challengeStartDate"
@@ -36,8 +36,8 @@ const ChallengeInputForm = () => {
             value={formik.values.challengeStartDate}
           />
         </div>
-        <div class="form-group">
-          <label for="challengeEndDate">Challenge end date </label>
+        <div className="form-group">
+          <label htmlFor="challengeEndDate">Challenge end date </label>
           <input
             type="date"
             id="challengeEndDate"
@@ -45,8 +45,8 @@ const ChallengeInputForm = () => {
             value={formik.values.challengeEndDate}
           />
         </div>
-        <div class="form-group">
-          <label for="challengePassphrase">
+        <div className="form-group">
+          <label htmlFor="challengePassphrase">
             Passphrase to enter challenge (auto-generated if left empty){' '}
           </label>
           <input

--- a/src/Contents/Contents.js
+++ b/src/Contents/Contents.js
@@ -1,0 +1,25 @@
+import { useStrava } from '../StravaContainer';
+import ChallengeInputForm from './ChallengeInputForm';
+
+const Contents = () => {
+  const token = useStrava();
+
+  return (
+    <div className="stravaChallenge">
+      <h1>The Strava Challenge</h1>
+      <div>Your Strava token is: {token}</div>
+      <div className="challengeInputForm">
+        <ChallengeInputForm />
+      </div>
+      <div className="challengeList">
+        <div>{/* status */}</div>
+        <ol>{/* TODO */}</ol>
+      </div>
+      <div className="footer">
+        <p>&copy; alexdiem.io</p>
+      </div>
+    </div>
+  );
+};
+
+export default Contents;

--- a/src/Contents/index.js
+++ b/src/Contents/index.js
@@ -1,0 +1,1 @@
+export { default } from './Contents';

--- a/src/StravaContainer/StravaContainer.js
+++ b/src/StravaContainer/StravaContainer.js
@@ -9,9 +9,8 @@ const StravaTokenContext = createContext({
 });
 
 export const useStrava = () => {
-  const ctx = useContext(StravaTokenContext);
-  console.log(ctx);
-  return ctx.token;
+  const { token } = useContext(StravaTokenContext);
+  return token;
 };
 
 const StravaContainer = ({ children }) => {

--- a/src/StravaContainer/StravaContainer.js
+++ b/src/StravaContainer/StravaContainer.js
@@ -57,7 +57,6 @@ const StravaContainer = ({ children }) => {
     );
   }
 
-  console.log('token', token);
 
   return (
     <StravaTokenContext.Provider value={{ token }}>

--- a/src/StravaContainer/StravaContainer.js
+++ b/src/StravaContainer/StravaContainer.js
@@ -1,0 +1,69 @@
+import { createContext, useContext, useState } from 'react';
+import OAuth2Login from 'react-simple-oauth2-login';
+
+const { REACT_APP_STRAVA_CLIENT_ID, REACT_APP_STRAVA_CLIENT_SECRET } =
+  process.env;
+
+const StravaTokenContext = createContext({
+  token: '',
+});
+
+export const useStrava = () => {
+  const ctx = useContext(StravaTokenContext);
+  console.log(ctx);
+  return ctx.token;
+};
+
+const StravaContainer = ({ children }) => {
+  const [token, setToken] = useState('');
+  const [error, setError] = useState('');
+
+  const errors = [];
+  if (!REACT_APP_STRAVA_CLIENT_ID) {
+    errors.push('Missing REACT_APP_STRAVA_CLIENT_ID');
+  }
+  if (!REACT_APP_STRAVA_CLIENT_SECRET) {
+    errors.push('Missing REACT_APP_STRAVA_CLIENT_SECRET');
+  }
+
+  if (errors.length) {
+    return (
+      <div>
+        <h1>Missing OAuth configuration</h1>
+        <ul>
+          {errors.map((error) => (
+            <li key={error}>{error}</li>
+          ))}
+        </ul>
+      </div>
+    );
+  }
+
+  if (error) {
+    return <pre>{error}</pre>;
+  }
+
+  if (!token) {
+    return (
+      <OAuth2Login
+        authorizationUrl="https://www.strava.com/oauth/authorize"
+        responseType="code"
+        clientId={REACT_APP_STRAVA_CLIENT_ID}
+        redirectUri={window.location}
+        onSuccess={({ code }) => setToken(code)}
+        onError={(e) => setError(e)}
+        scope="read"
+      />
+    );
+  }
+
+  console.log('token', token);
+
+  return (
+    <StravaTokenContext.Provider value={{ token }}>
+      {children}
+    </StravaTokenContext.Provider>
+  );
+};
+
+export default StravaContainer;

--- a/src/StravaContainer/index.js
+++ b/src/StravaContainer/index.js
@@ -1,0 +1,2 @@
+export { default } from './StravaContainer';
+export * from './StravaContainer';

--- a/yarn.lock
+++ b/yarn.lock
@@ -9077,6 +9077,11 @@ react-scripts@4.0.3:
   optionalDependencies:
     fsevents "^2.1.3"
 
+react-simple-oauth2-login@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/react-simple-oauth2-login/-/react-simple-oauth2-login-0.2.0.tgz#d09bc3e086978f49c3c7013cbe42590230aa2f0f"
+  integrity sha512-rVQJN/ngEpHK9uQl6S7ymtm0o39c7t/kUxjJg6Yy1uL7A9At0YqjhAw1mDVj2ht9EkVGE8QgzYbXZElRC2OeFQ==
+
 react@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"


### PR DESCRIPTION
Support fetching the user's Strava token with the introduction of a
StravaContainer. The way this component works is that, until a user is
authenticated against Strava, they'll just be shown a button to log in
Strava. Once they're logged in, any provided children (the rest of the
tree) will be rendered. The children can access the user's Strava token
using the `useStrava()` hook.

This also cleans up the source tree to make things a little more
maintainable and make the API boundaries more clear.

Finally, it also corrects some errors (`for` needs to be `htmlFor`;
`class` needs to be `className`) in the JSX, too.